### PR TITLE
Launch jlab with asynchronous=True

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -87,7 +87,13 @@ def start(
     session = Connection(host, connect_kwargs={'password': password})
 
     # jupyter lab will pipe output to logfile, which should not exist prior to running
-    logfile = f'~/.jforward.{port}'
+    # Logfile will be in $TMPDIR if defined on the remote machine, otherwise in $HOME
+    tmpdir = session.run('echo $TMPDIR', hide=True).stdout.strip()
+    if len(tmpdir) == 0:
+        tmpdir = session.run('echo $HOME', hide=True).stdout.strip()
+        if len(tmpdir) == 0:
+            tmpdir = '~'
+    logfile = f'{tmpdir}/.jforward.{port}'
     _ = session.run(f'rm -f {logfile}')
 
     # start jupyter lab on remote machine

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -1,6 +1,7 @@
 import dataclasses
 import getpass
 import random
+import time
 from collections import namedtuple
 
 import typer
@@ -83,8 +84,11 @@ def start(
     """
     password = getpass.getpass()
     session = Connection(host, connect_kwargs={'password': password})
+    logfile = f'~/.jforward.{port}'
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
-    _ = session.run(command)
+    jlab_exe = session.run(f'{command} > {logfile} 2>&1' , asynchronous=True)
+    time.sleep(1)
+    _ = session.run(f'tail -f {logfile}')
 
 
 @app.command()

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -85,10 +85,17 @@ def start(
     """
     password = getpass.getpass()
     session = Connection(host, connect_kwargs={'password': password})
+
+    # jupyter lab will pipe output to logfile, which should not exist prior to running
     logfile = f'~/.jforward.{port}'
+    _ = session.run(f'rm -f {logfile}')
+
+    # start jupyter lab on remote machine
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
     jlab_exe = session.run(f'{command} > {logfile} 2>&1', asynchronous=True)
     print(f'DEBUG: jlab_exe is of type {type(jlab_exe)}')
+
+    # wait for logfile to contain access info, then write it to screen
     condition = True
     pattern = 'To access the notebook, open this file in a browser:'
     while condition:

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -86,7 +86,8 @@ def start(
     session = Connection(host, connect_kwargs={'password': password})
     logfile = f'~/.jforward.{port}'
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
-    jlab_exe = session.run(f'{command} > {logfile} 2>&1' , asynchronous=True)
+    jlab_exe = session.run(f'{command} > {logfile} 2>&1', asynchronous=True)
+    print(f'DEBUG: jlab_exe is of type {type(jlab_exe)}')
     time.sleep(1)
     _ = session.run(f'tail -f {logfile}')
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -3,6 +3,7 @@ import getpass
 import random
 from collections import namedtuple
 
+import invoke
 import typer
 from fabric import Connection
 
@@ -91,10 +92,14 @@ def start(
     condition = True
     pattern = 'To access the notebook, open this file in a browser:'
     while condition:
-        result = session.run(f'tail {logfile}', hide='out')
-        if pattern in result.stdout:
-            condition = False
-            print(result.stdout)
+        try:
+            result = session.run(f'tail {logfile}', hide='out')
+            if pattern in result.stdout:
+                condition = False
+                print(result.stdout)
+        except invoke.exceptions.UnexpectedExit:
+            print(f'Trying to access {logfile} on {host} again...')
+            pass
 
 
 @app.command()

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -1,13 +1,13 @@
 import dataclasses
 import getpass
 import random
-import time
 from collections import namedtuple
 
 import typer
 from fabric import Connection
 
 random.seed(42)
+
 
 app = typer.Typer(help='Jupyter Lab Port Forwarding Utility')
 
@@ -88,8 +88,13 @@ def start(
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
     jlab_exe = session.run(f'{command} > {logfile} 2>&1', asynchronous=True)
     print(f'DEBUG: jlab_exe is of type {type(jlab_exe)}')
-    time.sleep(1)
-    _ = session.run(f'tail -f {logfile}')
+    condition = True
+    pattern = 'To access the notebook, open this file in a browser:'
+    while condition:
+        result = session.run(f'tail {logfile}', hide='out')
+        if pattern in result.stdout:
+            condition = False
+            print(result.stdout)
 
 
 @app.command()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=jupyter_forward
-known_third_party=fabric,pkg_resources,pytest,setuptools,typer
+known_third_party=fabric,invoke,pkg_resources,pytest,setuptools,typer
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
I think piping the output to a log file is necessary so we can grab the port and token; for now I'm just printing the log file to `stdout` in a separate run command to show that `asynchronous` is working correctly.

Fixes #3 