### PR TITLE
Add port_forwarding and open_browser functions

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -187,7 +187,8 @@ def start(
     if port_forwarding:
         setup_port_forwarding(parsed_result['port'], session.user, parsed_result['hostname'])
         open_browser(port=parsed_result['port'], token=parsed_result['token'])
-    open_browser(url=parsed_result['url'])
+    else:
+        open_browser(url=parsed_result['url'])
 
 
 @app.command()

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -1,6 +1,7 @@
 import dataclasses
 import getpass
 import random
+import time
 from collections import namedtuple
 
 import typer
@@ -83,8 +84,11 @@ def start(
     """
     password = getpass.getpass()
     session = Connection(host, connect_kwargs={'password': password})
+    logfile = f'~/.jforward.{port}'
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
-    _ = session.run(command)
+    jlab_exe = session.run(f'{command} > {logfile} 2>&1' , asynchronous=True)
+    time.sleep(1)
+    _ = session.run(f'tail -f {logfile}')
 
 
 @app.command()

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -39,6 +39,8 @@ def open_browser(port=None, token=None, url=None):
     import webbrowser
 
     if not url:
+        if port is None:
+            raise ValueError('Please specify port number to use.')
         url = f'http://localhost:{port}'
         if token:
             url = f'{url}/?token={token}'

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -86,7 +86,8 @@ def start(
     session = Connection(host, connect_kwargs={'password': password})
     logfile = f'~/.jforward.{port}'
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
-    jlab_exe = session.run(f'{command} > {logfile} 2>&1' , asynchronous=True)
+    jlab_exe = session.run(f'{command} > {logfile} 2>&1', asynchronous=True)
+    print(f'DEBUG: jlab_exe is of type {type(jlab_exe)}')
     time.sleep(1)
     _ = session.run(f'tail -f {logfile}')
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -48,7 +48,7 @@ def open_browser(port=None, token=None, url=None):
 
 def setup_port_forwarding(port, username, hostname):
     print('*** Setting up port forwarding ***')
-    command = f'ssh -N -L {port}:localhost:{port} {username}@{hostname} &'
+    command = f'ssh -N -L {port}:localhost:{port} {username}@{hostname}'
     print(command)
     invoke.run(command, asynchronous=True)
     time.sleep(3)

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -1,13 +1,13 @@
 import dataclasses
 import getpass
 import random
-import time
 from collections import namedtuple
 
 import typer
 from fabric import Connection
 
 random.seed(42)
+
 
 app = typer.Typer(help='Jupyter Lab Port Forwarding Utility')
 
@@ -88,8 +88,13 @@ def start(
     command = f'conda activate {conda_env} &&  jupyter lab --no-browser --ip=`hostname` --port={port} --notebook-dir={notebook_dir}'
     jlab_exe = session.run(f'{command} > {logfile} 2>&1', asynchronous=True)
     print(f'DEBUG: jlab_exe is of type {type(jlab_exe)}')
-    time.sleep(1)
-    _ = session.run(f'tail -f {logfile}')
+    condition = True
+    pattern = 'To access the notebook, open this file in a browser:'
+    while condition:
+        result = session.run(f'tail {logfile}', hide='out')
+        if pattern in result.stdout:
+            condition = False
+            print(result.stdout)
 
 
 @app.command()

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -35,7 +35,25 @@ Host {self.host}
         print(template)
 
 
-def open_browser(port=None, token=None, url=None):
+def open_browser(port: int = None, token: str = None, url: str = None):
+    """
+    Opens notebook interface in a new browser window.
+
+    Parameters
+    ----------
+    port : int, optional
+        Port number to use, by default None
+    token : str, optional
+        token used for authentication, by default None
+    url : str, optional
+        Notebook url, by default None
+
+    Raises
+    ------
+    ValueError
+        If url is None and port is None
+    """
+
     import webbrowser
 
     if not url:
@@ -48,7 +66,17 @@ def open_browser(port=None, token=None, url=None):
     webbrowser.open(url, new=2)
 
 
-def setup_port_forwarding(port, username, hostname):
+def setup_port_forwarding(port: int, username: str, hostname: str):
+    """
+    Sets up SSH port forwarding
+
+    Parameters
+    ----------
+    port : int
+        port number to use
+    username : str
+    hostname : str
+    """
     print('*** Setting up port forwarding ***')
     command = f'ssh -N -L {port}:localhost:{port} {username}@{hostname}'
     print(command)
@@ -56,7 +84,7 @@ def setup_port_forwarding(port, username, hostname):
     time.sleep(3)
 
 
-def parse_stdout(stdout):
+def parse_stdout(stdout: str):
     hostname, port, token, url = None, None, None, None
     stdout = stdout.splitlines()
     for line in stdout:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ select = B,C,E,F,W,T4,B9
 
 [isort]
 known_first_party=jupyter_forward
-known_third_party=fabric,pkg_resources,pytest,setuptools,typer
+known_third_party=fabric,invoke,pkg_resources,pytest,setuptools,typer
 multi_line_output=3
 include_trailing_comma=True
 force_grid_wrap=0


### PR DESCRIPTION
This PR piggybacks off of #4, and adds two functions:

- `open_browser`
-  `setup_port_forwarding`

As an example, here's how this works on CGD's hobart (which doesn't need to the port forwarding):

```bash
❯ jupyter-forward start abanihi@hobart.cgd.ucar.edu --notebook-dir /scratch/cluster/abanihi --no-port-forwarding
Password: 
DEBUG: jlab_exe is of type <class 'invoke.runners.Promise'>
*** Opening Jupyter Lab interface in a browser at ***
*** http://hobart.cgd.ucar.edu:59629/?token=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX ***
```


