### PR TITLE
Remove random port generation

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -3,6 +3,7 @@ import getpass
 import random
 import socket
 import time
+import uuid
 from collections import namedtuple
 
 import invoke
@@ -204,7 +205,7 @@ def start(
             tmpdir = '~'
     log_dir = f'{tmpdir}/.jupyter_forward'
     session.run(f'mkdir -p {log_dir}', **kwargs)
-    logfile = f'{log_dir}/jforward.{port}'
+    logfile = f'{log_dir}/jforward.{uuid.uuid1()}'
     session.run(f'rm -f {logfile}', **kwargs)
 
     # start jupyter lab on remote machine

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -167,7 +167,7 @@ def start(
     host: str,
     port: int = typer.Option(
         8888,
-        help='The port the notebook server will listen on. If not specified, defaults to port used by the remote notebook server.',
+        help='The local port the remote notebook server will be forwarded to. If not specified, defaults to 8888.',
         show_default=True,
     ),
     conda_env: str = typer.Option(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -94,17 +94,18 @@ def test_open_browser(port, token, url, expected):
 
 
 @pytest.mark.parametrize(
-    'session, parsed_results, logfile, url',
+    'session, parsed_results, logfile, url, port',
     [
         (
             fabric.Connection('example.com'),
             {'port': 9999, 'hostname': 'example.com', 'token': 'foobar'},
             'logfile.txt',
-            'http://localhost:9999/?token=foobar',
+            'http://localhost:8888/?token=foobar',
+            8888,
         )
     ],
 )
-def test_setup_port_forwarding(session, parsed_results, logfile, url):
+def test_setup_port_forwarding(session, parsed_results, logfile, url, port):
     @contextmanager
     def forward_local(
         self, local_port, remote_port=None, remote_host='localhost', local_host='localhost'
@@ -120,6 +121,6 @@ def test_setup_port_forwarding(session, parsed_results, logfile, url):
     ) as _, mock.patch.object(fabric.Connection, 'run', run) as mockrun, mock.patch(
         'webbrowser.open'
     ) as mockwebopen:
-        setup_port_forwarding(session, parsed_results, logfile)
+        setup_port_forwarding(session, parsed_results, logfile, port)
         mockrun.assert_called_once_with(session, 'tail -f logfile.txt', pty=True)
         mockwebopen.assert_called_once_with(url, new=2)


### PR DESCRIPTION
Towards fixing #16. With this PR, we are still using the same `local_port` as the `remote_port`. Since we are opening the browser for the user, I didn't see that much benefit to setting the `local_port`. 

