### PR TITLE
Tcsh support

### DIFF
--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -50,7 +50,7 @@ class RemoteRunner:
     shell: str = '/usr/bin/env bash'
 
     def __post_init__(self):
-        self.run_kwargs = dict(pty=True, shell=self.shell)
+        self.run_kwargs = dict(pty=True)
         console.rule('[bold green]Authentication', characters='*')
         if self.port_forwarding and not is_port_available(self.port):
             console.log(

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -90,7 +90,7 @@ class RemoteRunner:
 
         console.log('[bold cyan]:white_check_mark: The client is authenticated successfully')
 
-    def _jupyter_info(self, command='command -v jupyter'):
+    def _jupyter_info(self, command='sh -c "command -v jupyter"'):
         console.rule('[bold green]Running jupyter sanity checks', characters='*')
         out = self.session.run(command, warn=True, hide='out', **self.run_kwargs)
         if out.failed:
@@ -136,14 +136,16 @@ class RemoteRunner:
         # Logfile will be in $TMPDIR if defined on the remote machine, otherwise in $HOME
 
         try:
-            check_jupyter_status = 'command -v jupyter'
+            check_jupyter_status = 'sh -c "command -v jupyter"'
             if self.conda_env:
-                check_jupyter_status = f'conda activate {self.conda_env} && command -v jupyter'
+                check_jupyter_status = (
+                    f'conda activate {self.conda_env} && sh -c "command -v jupyter"'
+                )
             self._jupyter_info(check_jupyter_status)
-            if self.dir_exists('$TMPDIR'):
-                self.log_dir = '$TMPDIR'
-            else:
-                self.log_dir = '$HOME'
+            # if self.dir_exists('$TMPDIR'):
+            #    self.log_dir = '$TMPDIR'
+            # else:
+            self.log_dir = '$HOME'
 
             self.log_dir = f'{self.log_dir}/.jupyter_forward'
             self.session.run(f'mkdir -p {self.log_dir}', **self.run_kwargs)
@@ -158,7 +160,7 @@ class RemoteRunner:
                 command = f'{command} --ip=`hostname`'
             if self.notebook_dir:
                 command = f'{command} --notebook-dir={self.notebook_dir}'
-            command = f'{command} > {self.log_file} 2>&1'
+            command = f'{command} >& {self.log_file}'
             if self.conda_env:
                 command = f'conda activate {self.conda_env} && {command}'
 

--- a/jupyter_forward/core.py
+++ b/jupyter_forward/core.py
@@ -150,8 +150,23 @@ class RemoteRunner:
             self._jupyter_info(check_jupyter_status)
             if self.envvar_exists('TMPDIR') and self.dir_exists('$TMPDIR'):
                 self.log_dir = '$TMPDIR'
-            else:
+            elif self.envvar_exists('HOME') and self.dir_exists('$HOME'):
                 self.log_dir = '$HOME'
+            else:
+                message = (
+                    '$TMPDIR/ is not a directory'
+                    if self.envvar_exists('TMPDIR')
+                    else '$TMPDIR is not defined'
+                )
+                console.log(f'[bold red]{message}')
+                message = (
+                    '$HOME/ is not a directory'
+                    if self.envvar_exists('HOME')
+                    else '$HOME is not defined'
+                )
+                console.log(f'[bold red]{message}')
+                console.log('[bold red]Can not determine directory for log file')
+                sys.exit(1)
 
             self.log_dir = f'{self.log_dir}/.jupyter_forward'
             self.session.run(f'mkdir -p {self.log_dir}', **self.run_kwargs)


### PR DESCRIPTION
Cecile H reported problems running jupyter forward, and @andersy005 tracked it down to a few `bash` commands that we were executing on the remote machine (she uses `tcsh` by default). We were able to get her running with some kludgy updates, but this PR cleans everything up.

Testing: I created a VM where my default shell was `tcsh`, and verified that I could not use `jupyter-forward` out of the box. After the following commits I was able to use `jupyter-forward` to get to my virtual machine, and could still use it to connect to machines where my default shell is `bash`.

Fixes #66