### PR TITLE
Force login shell

### DIFF
--- a/jupyter_forward/cli.py
+++ b/jupyter_forward/cli.py
@@ -61,7 +61,7 @@ def start(
         ),
     ),
     shell: str = typer.Option(
-        '/usr/bin/env bash',
+        '/usr/bin/sh -l',
         '--shell',
         '-s',
         show_default=True,


### PR DESCRIPTION
This PR replaces the default `/usr/bin/env bash` with `/usr/bin/sh -l` to use the login shell by default. This addresses some strange behaviors on systems such as casper. 